### PR TITLE
Class overload ambiguity fix

### DIFF
--- a/library/src/commonMain/kotlin/transcribe/TranscriberMapBuilder.kt
+++ b/library/src/commonMain/kotlin/transcribe/TranscriberMapBuilder.kt
@@ -24,13 +24,6 @@ class TranscriberMapBuilder<N : Any, T : Transcriber<N, *>> {
     }
 
     /**
-     * Add transcriber with java.lang.Class (Java).
-     */
-    fun add(nodeClass: Class<out N>, transcriber: T): TranscriberMapBuilder<N, T> {
-        return add(nodeClass.kotlin, transcriber)
-    }
-
-    /**
      * Add all transcribers from an existing map.
      */
     fun addAll(transcriberMap: Map<KClass<out N>, T>): TranscriberMapBuilder<N, T> {

--- a/library/src/commonTest/kotlin/transcribe/TranscriberMapBuilderTest.kt
+++ b/library/src/commonTest/kotlin/transcribe/TranscriberMapBuilderTest.kt
@@ -37,21 +37,6 @@ class TranscriberMapBuilderTest {
     }
 
     @Test
-    fun add_javaClass() {
-        val transcriber1 = TestTranscriber("transcriber1")
-        val transcriber2 = TestTranscriber("transcriber2")
-
-        val map = TranscriberMapBuilder<TestNode, TestTranscriber>()
-            .add(TestNodeA::class.java, transcriber1)
-            .add(TestNodeB::class.java, transcriber2)
-            .build()
-
-        assertEquals(2, map.size)
-        assertEquals(transcriber1, map[TestNodeA::class])
-        assertEquals(transcriber2, map[TestNodeB::class])
-    }
-
-    @Test
     fun addAll_existingMap() {
         val transcriber1 = TestTranscriber("transcriber1")
         val transcriber2 = TestTranscriber("transcriber2")


### PR DESCRIPTION
Remove `java.lang.Class` overload to resolve native target overload ambiguity.

The `java.lang.Class` overload in `TranscriberMapBuilder` caused overload resolution ambiguity on native targets because `java.lang.Class` is JVM-specific and should not be present in `commonMain` for a multiplatform project. This change ensures `KClass` is used consistently across all platforms.

---
<a href="https://cursor.com/background-agent?bcId=bc-873bd443-fb40-4e7e-a684-594437f7bf90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-873bd443-fb40-4e7e-a684-594437f7bf90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

