### PR TITLE
Fix image attachment links

### DIFF
--- a/library/src/commonMain/kotlin/io/ncipollo/transcribe/Transcribe.kt
+++ b/library/src/commonMain/kotlin/io/ncipollo/transcribe/Transcribe.kt
@@ -83,6 +83,7 @@ class Transcribe(
             commentTransformer = commentTransformer,
             actionHandler = actionHandler,
             toMarkdownTransformer = configuration.toMarkdownTransformer,
+            siteName = configuration.confluenceConfiguration.siteName,
         )
     }
 

--- a/library/src/commonMain/kotlin/io/ncipollo/transcribe/context/ADFTranscriberContext.kt
+++ b/library/src/commonMain/kotlin/io/ncipollo/transcribe/context/ADFTranscriberContext.kt
@@ -7,6 +7,7 @@ data class ADFTranscriberContext(
     val pageContext: PageContext = PageContext(),
     val attachmentContext: AttachmentContext = AttachmentContext(),
     val listLevel: Int = 0,
+    val baseWikiUrl: String = "",
 ) {
     val suggestedDocumentName: String by lazy {
         pageContext.title.dropExtension().toSnakeCase()

--- a/library/src/commonMain/kotlin/io/ncipollo/transcribe/feature/PageMarkdownFetchFeature.kt
+++ b/library/src/commonMain/kotlin/io/ncipollo/transcribe/feature/PageMarkdownFetchFeature.kt
@@ -33,6 +33,7 @@ class PageMarkdownFetchFeature(
     private val commentTransformer: CommentTransformer,
     private val actionHandler: ActionHandler,
     private val toMarkdownTransformer: ADFTransformer<ADFTranscriberContext>,
+    private val siteName: String,
 ) {
     /**
      * Fetches a Confluence page by ID and returns its content as Markdown.
@@ -65,6 +66,7 @@ class PageMarkdownFetchFeature(
         val context = ADFTranscriberContext(
             pageContext = PageContext.fromPageResponse(page),
             attachmentContext = AttachmentContext.from(attachments),
+            baseWikiUrl = "https://$siteName.atlassian.net/wiki",
         )
         val transformedContent = toMarkdownTransformer.transform(adfBody.content, context)
         val transformedDocNode = adfBody.copy(content = transformedContent)

--- a/library/src/commonMain/kotlin/io/ncipollo/transcribe/transcriber/atlassian/MediaSingleNodeTranscriber.kt
+++ b/library/src/commonMain/kotlin/io/ncipollo/transcribe/transcriber/atlassian/MediaSingleNodeTranscriber.kt
@@ -25,10 +25,15 @@ class MediaSingleNodeTranscriber : ADFTranscriber<MediaSingleNode> {
             ?: return TranscribeResult("")
 
         val downloadLink = attachment.downloadLink ?: return TranscribeResult("")
+        val fullDownloadLink = if (downloadLink.startsWith("/") && context.baseWikiUrl.isNotEmpty()) {
+            "${context.baseWikiUrl}$downloadLink"
+        } else {
+            downloadLink
+        }
 
         val altText = mediaNode.attrs.alt ?: ""
         val imagePath = imagePath(context, attachment)
-        val action = downloadAction(imagePath, downloadLink)
+        val action = downloadAction(imagePath, fullDownloadLink)
 
         return TranscribeResult("![$altText]($imagePath)\n", listOf(action))
     }

--- a/library/src/jvmTest/kotlin/io/ncipollo/transcribe/feature/PageMarkdownFetchFeatureTest.kt
+++ b/library/src/jvmTest/kotlin/io/ncipollo/transcribe/feature/PageMarkdownFetchFeatureTest.kt
@@ -39,6 +39,7 @@ class PageMarkdownFetchFeatureTest {
         commentTransformer = commentTransformer,
         actionHandler = actionHandler,
         toMarkdownTransformer = toMarkdownTransformer,
+        siteName = "test-site",
     )
 
     @Test


### PR DESCRIPTION
- Fixed media node image download links not correctly capturing the base site name (was not including the wiki suffix on the path)
- Fixed auth material not surviving across redirects when fetching drawio images.
- No longer attaching auth material to non-attlassian endpoints.