### PR TITLE
fix(formatting): add newline before divider

### DIFF
--- a/library/src/commonMain/kotlin/io/ncipollo/transcribe/transcriber/atlassian/RuleNodeTranscriber.kt
+++ b/library/src/commonMain/kotlin/io/ncipollo/transcribe/transcriber/atlassian/RuleNodeTranscriber.kt
@@ -13,6 +13,6 @@ class RuleNodeTranscriber : ADFTranscriber<RuleNode> {
         input: RuleNode,
         context: ADFTranscriberContext,
     ): TranscribeResult<String> {
-        return TranscribeResult("---\n\n")
+        return TranscribeResult("\n---\n\n")
     }
 }

--- a/library/src/commonTest/kotlin/io/ncipollo/transcribe/transcriber/atlassian/RuleNodeTranscriberTest.kt
+++ b/library/src/commonTest/kotlin/io/ncipollo/transcribe/transcriber/atlassian/RuleNodeTranscriberTest.kt
@@ -13,6 +13,6 @@ class RuleNodeTranscriberTest {
     fun transcribe_basic() {
         val node = RuleNode()
         val result = transcriber.transcribe(node, context)
-        assertEquals("---\n\n", result.content)
+        assertEquals("\n---\n\n", result.content)
     }
 }


### PR DESCRIPTION
Without a leading newline, the `---` could merge with preceding text and bold it, causing formatting errors.